### PR TITLE
Add phone-style home screen layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MyHome Overview Demo
+
+Eerste iteratie van het homescherm voor de MyHome Overview demo. De pagina
+simuleert een mobiele lay-out met een menubalk en een blauwdrukpaneel waarop de
+gebruiker straks kan inzoomen naar huis, garage en auto.
+
+## Inhoud
+- `index.html` — statische HTML-pagina met de homeschermstructuur.
+- `styles/main.css` — stijlen voor het telefoonframe, navigatie en blauwdruk.
+
+## Gebruik
+Open `index.html` in een moderne browser. De pagina is responsief en blijft in
+telefoonverhouding (9:19.5) zodat hij representatief is voor de Android-app die
+later gebouwd wordt.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MyHome Overview</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Urbanist:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles/main.css" />
+  </head>
+  <body>
+    <main class="viewport">
+      <section class="phone-frame">
+        <header class="app-header">
+          <div class="status-bar">
+            <span class="status-time">09:41</span>
+            <div class="status-icons" aria-hidden="true">
+              <span class="icon signal"></span>
+              <span class="icon wifi"></span>
+              <span class="icon battery"></span>
+            </div>
+          </div>
+          <div class="top-bar">
+            <div>
+              <p class="welcome">Welkom terug</p>
+              <h1 class="title">Jouw woningoverzicht</h1>
+            </div>
+            <button class="avatar" type="button" aria-label="Open profiel">
+              <span>JD</span>
+            </button>
+          </div>
+          <div class="search">
+            <input type="search" placeholder="Zoek naar spullen..." aria-label="Zoek naar items" />
+          </div>
+        </header>
+        <section class="blueprint-panel" aria-label="Interactieve blauwdruk">
+          <div class="layer layer-home">
+            <h2>Huis</h2>
+            <p>Zoom in om kamers te bekijken</p>
+          </div>
+          <div class="layer layer-garage">
+            <h2>Garage</h2>
+            <p>Voertuigen en gereedschap</p>
+          </div>
+          <div class="layer layer-car">
+            <h2>Auto</h2>
+            <p>Bekijk kofferruimte en dashboard</p>
+          </div>
+        </section>
+        <section class="quick-actions" aria-label="Snelle acties">
+          <button type="button" class="action primary">
+            <span class="action-icon">＋</span>
+            <span class="action-label">Nieuw item</span>
+          </button>
+          <button type="button" class="action">
+            <span class="action-icon">📷</span>
+            <span class="action-label">Foto maken</span>
+          </button>
+          <button type="button" class="action">
+            <span class="action-icon">✨</span>
+            <span class="action-label">Genereer beeld</span>
+          </button>
+        </section>
+        <nav class="bottom-nav" aria-label="Hoofdmenu">
+          <button type="button" class="nav-button active">
+            <span class="nav-icon">🏠</span>
+            <span class="nav-label">Overzicht</span>
+          </button>
+          <button type="button" class="nav-button">
+            <span class="nav-icon">📦</span>
+            <span class="nav-label">Inventaris</span>
+          </button>
+          <button type="button" class="nav-button">
+            <span class="nav-icon">🛒</span>
+            <span class="nav-label">Suggesties</span>
+          </button>
+          <button type="button" class="nav-button">
+            <span class="nav-icon">⚙️</span>
+            <span class="nav-label">Instellingen</span>
+          </button>
+        </nav>
+      </section>
+    </main>
+  </body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,0 +1,338 @@
+:root {
+  color-scheme: light;
+  font-family: 'Urbanist', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background-color: #0f172a;
+  --blue-900: #0f172a;
+  --blue-800: #172554;
+  --blue-600: #2563eb;
+  --blue-400: #60a5fa;
+  --blue-200: #bfdbfe;
+  --blueprint-line: rgba(148, 163, 184, 0.25);
+  --surface: rgba(15, 23, 42, 0.65);
+  --white: #f8fafc;
+  --shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.35), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(96, 165, 250, 0.35), transparent 50%),
+    var(--blue-900);
+  color: var(--white);
+}
+
+.viewport {
+  width: min(100vw, 480px);
+  padding: clamp(16px, 2.5vw, 24px);
+}
+
+.phone-frame {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+  aspect-ratio: 9 / 19.5;
+  border-radius: 32px;
+  padding: 18px 18px 28px;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(30, 64, 175, 0.65));
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  overflow: hidden;
+}
+
+.phone-frame::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(90deg, transparent 95%, rgba(148, 163, 184, 0.15) 95%),
+    linear-gradient(0deg, transparent 95%, rgba(148, 163, 184, 0.15) 95%);
+  background-size: 24px 24px;
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.app-header {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  z-index: 1;
+}
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  opacity: 0.8;
+}
+
+.status-icons {
+  display: flex;
+  gap: 12px;
+}
+
+.status-icons .icon {
+  display: inline-block;
+  width: 18px;
+  height: 12px;
+  border-radius: 4px;
+  border: 1px solid rgba(248, 250, 252, 0.6);
+  position: relative;
+}
+
+.status-icons .battery::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  right: 4px;
+  bottom: 2px;
+  border-radius: 2px;
+  background: var(--blue-200);
+}
+
+.status-icons .signal::after,
+.status-icons .wifi::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 2px;
+  background: var(--blue-400);
+  opacity: 0.8;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.welcome {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(191, 219, 254, 0.9);
+}
+
+.title {
+  margin: 4px 0 0;
+  font-size: clamp(1.5rem, 4vw, 1.75rem);
+  font-weight: 700;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  border: none;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(37, 99, 235, 0.9));
+  color: var(--white);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: transform 0.25s ease;
+}
+
+.avatar:focus-visible,
+.avatar:hover {
+  transform: translateY(-2px) scale(1.02);
+}
+
+.search {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.search input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--white);
+  font-size: 0.95rem;
+}
+
+.search input::placeholder {
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.search input:focus {
+  outline: none;
+}
+
+.blueprint-panel {
+  position: relative;
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 18px;
+  border-radius: 24px;
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.12), rgba(15, 23, 42, 0.75));
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  overflow: hidden;
+}
+
+.blueprint-panel::before {
+  content: '';
+  position: absolute;
+  inset: -120px;
+  background: radial-gradient(
+      40% 60% at 20% 20%,
+      rgba(59, 130, 246, 0.4),
+      transparent
+    ),
+    radial-gradient(35% 50% at 80% 30%, rgba(96, 165, 250, 0.35), transparent),
+    linear-gradient(90deg, rgba(96, 165, 250, 0.2), transparent 65%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.layer {
+  position: relative;
+  z-index: 1;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.layer:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.65);
+}
+
+.layer h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.layer p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(191, 219, 254, 0.75);
+}
+
+.quick-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  z-index: 1;
+}
+
+.action {
+  border: none;
+  border-radius: 18px;
+  padding: 12px 10px;
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--white);
+  display: grid;
+  place-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.action.primary {
+  background: linear-gradient(145deg, rgba(37, 99, 235, 0.95), rgba(96, 165, 250, 0.9));
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+}
+
+.action:hover,
+.action:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(37, 99, 235, 0.35);
+}
+
+.action.primary:hover,
+.action.primary:focus-visible {
+  background: linear-gradient(145deg, rgba(37, 99, 235, 1), rgba(96, 165, 250, 1));
+}
+
+.action-icon {
+  font-size: 1.4rem;
+}
+
+.bottom-nav {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: center;
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 22px;
+  padding: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.1);
+  z-index: 1;
+}
+
+.nav-button {
+  background: none;
+  border: none;
+  color: rgba(191, 219, 254, 0.75);
+  font: inherit;
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  padding: 8px 4px;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: color 0.25s ease, background 0.25s ease;
+}
+
+.nav-button.active {
+  color: var(--white);
+  background: rgba(37, 99, 235, 0.35);
+}
+
+.nav-button:focus-visible,
+.nav-button:hover {
+  color: var(--white);
+}
+
+.nav-icon {
+  font-size: 1.25rem;
+}
+
+.nav-label {
+  font-size: 0.75rem;
+}
+
+@media (max-width: 420px) {
+  .viewport {
+    padding: 12px;
+  }
+
+  .phone-frame {
+    border-radius: 24px;
+  }
+
+  .layer {
+    padding: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a static HTML home screen that mimics an Android phone viewport with status and menu bars
- add blueprint-inspired content blocks for house, garage, and car along with quick actions
- style the page with a blue/white blueprint theme using gradients and responsive design

## Testing
- Not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cb1d49fd448323b2f0905ddf4e4436